### PR TITLE
add laradock default mysql password

### DIFF
--- a/passwords.csv
+++ b/passwords.csv
@@ -285,7 +285,7 @@ Costar,IP Camera system,,HTTP,root,root,,
 CyberPower,Remote Management Card RMCARD302,ANY,HTTP,cyber,cyber,Administrator,https://cdn.cnetcontent.com/25/1e/251e4f4c-b12e-4d32-860a-491a9bc5059a.pdf
 CyberPower,Remote Management Card RMCARD302,ANY,HTTP,device,cyber,Viewer,https://cdn.cnetcontent.com/25/1e/251e4f4c-b12e-4d32-860a-491a9bc5059a.pdf
 Cyclades,PR 1000,,Telnet,super,surt,Admin,mpacheco.inimigo.com
-Cyclades,TS800,,HTTP,root,tslinux,Admin,mpacheco.inimigo.com,
+Cyclades,TS800,,HTTP,root,tslinux,Admin,mpacheco.inimigo.com
 D-Link,AC1200,,HTTP,admin,admin,,
 D-Link,AC1750,,HTTP,admin,1234,,
 D-Link,Cable/DSL Routers/Switches,,Multi,<blank>,admin,Admin,


### PR DESCRIPTION
adding laradock default mysql password,
for those people still confused on laradock mysql user and password, you can check and maybe made change on laradock .env [mysql] and rebuild your mysql image